### PR TITLE
OI-3190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Fix path used to execute ssh-agent in cleanup.js to respect custom paths set by input (#235)
+
 ## v0.9.0 [2024-02-06]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.9.1 [2024-03-17]
+
 ### Fixed
 
 * Fix path used to execute ssh-agent in cleanup.js to respect custom paths set by input (#235)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.9.0 [2024-02-06]
+
+### Changed
+
+* Update all versions of `actions/checkout` to v4 (#199)
+* Update to Node 20 (#201)
+
+## v0.8.0 [2023-03-24]
+
+### Changed
+
+* No longer writing GitHub's SSH host keys to `known_hosts` (#171)
+* Update to actions/checkout@v3 (#143)
+* Allow the user to override the commands for git, ssh-agent, and ssh-add (#154)
+
 ## v0.7.0 [2022-10-19]
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
         description: 'git command'
         required: false
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'dist/index.js'
     post: 'dist/cleanup.js'
     post-if: 'always()'

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,4 +1,3 @@
-const core = require('@actions/core');
 const { execFileSync } = require('child_process');
 const { sshAgentCmd } = require('./paths.js');
 

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -292,14 +292,13 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
+exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__webpack_require__(747));
 const os = __importStar(__webpack_require__(87));
-const uuid_1 = __webpack_require__(62);
 const utils_1 = __webpack_require__(82);
-function issueFileCommand(command, message) {
+function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
@@ -311,22 +310,7 @@ function issueFileCommand(command, message) {
         encoding: 'utf8'
     });
 }
-exports.issueFileCommand = issueFileCommand;
-function prepareKeyValueMessage(key, value) {
-    const delimiter = `ghadelimiter_${uuid_1.v4()}`;
-    const convertedValue = utils_1.toCommandValue(value);
-    // These should realistically never happen, but just in case someone finds a
-    // way to exploit uuid generation let's not allow keys or values that contain
-    // the delimiter.
-    if (key.includes(delimiter)) {
-        throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
-    }
-    if (convertedValue.includes(delimiter)) {
-        throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
-    }
-    return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`;
-}
-exports.prepareKeyValueMessage = prepareKeyValueMessage;
+exports.issueCommand = issueCommand;
 //# sourceMappingURL=file-command.js.map
 
 /***/ }),
@@ -613,7 +597,6 @@ exports.debug = debug; // for test
 /***/ 175:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
-const core = __webpack_require__(470);
 const { execFileSync } = __webpack_require__(129);
 const { sshAgentCmd } = __webpack_require__(972);
 
@@ -1684,6 +1667,7 @@ const file_command_1 = __webpack_require__(102);
 const utils_1 = __webpack_require__(82);
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
+const uuid_1 = __webpack_require__(62);
 const oidc_utils_1 = __webpack_require__(742);
 /**
  * The code to exit an action
@@ -1713,9 +1697,20 @@ function exportVariable(name, val) {
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        return file_command_1.issueFileCommand('ENV', file_command_1.prepareKeyValueMessage(name, val));
+        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+        // These should realistically never happen, but just in case someone finds a way to exploit uuid generation let's not allow keys or values that contain the delimiter.
+        if (name.includes(delimiter)) {
+            throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+        }
+        if (convertedVal.includes(delimiter)) {
+            throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+        }
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
     }
-    command_1.issueCommand('set-env', { name }, convertedVal);
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
 }
 exports.exportVariable = exportVariable;
 /**
@@ -1733,7 +1728,7 @@ exports.setSecret = setSecret;
 function addPath(inputPath) {
     const filePath = process.env['GITHUB_PATH'] || '';
     if (filePath) {
-        file_command_1.issueFileCommand('PATH', inputPath);
+        file_command_1.issueCommand('PATH', inputPath);
     }
     else {
         command_1.issueCommand('add-path', {}, inputPath);
@@ -1773,10 +1768,7 @@ function getMultilineInput(name, options) {
     const inputs = getInput(name, options)
         .split('\n')
         .filter(x => x !== '');
-    if (options && options.trimWhitespace === false) {
-        return inputs;
-    }
-    return inputs.map(input => input.trim());
+    return inputs;
 }
 exports.getMultilineInput = getMultilineInput;
 /**
@@ -1809,12 +1801,8 @@ exports.getBooleanInput = getBooleanInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
-    const filePath = process.env['GITHUB_OUTPUT'] || '';
-    if (filePath) {
-        return file_command_1.issueFileCommand('OUTPUT', file_command_1.prepareKeyValueMessage(name, value));
-    }
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
+    command_1.issueCommand('set-output', { name }, value);
 }
 exports.setOutput = setOutput;
 /**
@@ -1943,11 +1931,7 @@ exports.group = group;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function saveState(name, value) {
-    const filePath = process.env['GITHUB_STATE'] || '';
-    if (filePath) {
-        return file_command_1.issueFileCommand('STATE', file_command_1.prepareKeyValueMessage(name, value));
-    }
-    command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
+    command_1.issueCommand('save-state', { name }, value);
 }
 exports.saveState = saveState;
 /**
@@ -2837,8 +2821,9 @@ exports.default = _default;
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
 const os = __webpack_require__(87);
+const core = __webpack_require__(470);
 
-module.exports = (process.env['OS'] != 'Windows_NT') ? {
+const defaults = (process.env['OS'] != 'Windows_NT') ? {
     // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
     // Action runs, where $HOME is different from the pwent
     homePath: os.userInfo().homedir,
@@ -2851,6 +2836,17 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     sshAgentCmdDefault: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmdDefault: 'c://progra~1//git//usr//bin//ssh-add.exe',
     gitCmdDefault: 'c://progra~1//git//bin//git.exe'
+};
+
+const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
+const sshAddCmdInput = core.getInput('ssh-add-cmd');
+const gitCmdInput = core.getInput('git-cmd');
+
+module.exports = {
+    homePath: defaults.homePath,
+    sshAgentCmd: sshAgentCmdInput !== '' ? sshAgentCmdInput : defaults.sshAgentCmdDefault,
+    sshAddCmd: sshAddCmdInput !== '' ? sshAddCmdInput : defaults.sshAddCmdDefault,
+    gitCmd: gitCmdInput !== '' ? gitCmdInput : defaults.gitCmdDefault,
 };
 
 

--- a/index.js
+++ b/index.js
@@ -2,19 +2,11 @@ const core = require('@actions/core');
 const child_process = require('child_process');
 const fs = require('fs');
 const crypto = require('crypto');
-const { homePath, sshAgentCmdDefault, sshAddCmdDefault, gitCmdDefault } = require('./paths.js');
+const { homePath, sshAgentCmd, sshAddCmd, gitCmd } = require('./paths.js');
 
 try {
     const privateKey = core.getInput('ssh-private-key');
     const logPublicKey = core.getBooleanInput('log-public-key', {default: true});
-
-    const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
-    const sshAddCmdInput = core.getInput('ssh-add-cmd');
-    const gitCmdInput = core.getInput('git-cmd');
-
-    const sshAgentCmd = sshAgentCmdInput ? sshAgentCmdInput : sshAgentCmdDefault;
-    const sshAddCmd = sshAddCmdInput ? sshAddCmdInput : sshAddCmdDefault;
-    const gitCmd = gitCmdInput ? gitCmdInput : gitCmdDefault;
 
     if (!privateKey) {
         core.setFailed("The ssh-private-key argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.");

--- a/paths.js
+++ b/paths.js
@@ -2,8 +2,9 @@ const os = require('os');
 const core = require('@actions/core');
 
 const defaults = (process.env['OS'] != 'Windows_NT') ? {
-    // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
-    // Action runs, where $HOME is different from the pwent
+    // We use os.userInfo() rather than os.homedir(), since it uses the getpwuid() system call to get the user's home directory (see https://nodejs.org/api/os.html#osuserinfooptions).
+    // This mimics the way openssh derives the home directory for locating config files (see https://github.com/openssh/openssh-portable/blob/826483d51a9fee60703298bbf839d9ce37943474/ssh.c#L710);
+    // Makes a difference in Docker-based Action runs, when $HOME is different from what getpwuid() returns (which is based on the entry in /etc/passwd)
     homePath: os.userInfo().homedir,
     sshAgentCmdDefault: 'ssh-agent',
     sshAddCmdDefault: 'ssh-add',

--- a/paths.js
+++ b/paths.js
@@ -1,6 +1,7 @@
 const os = require('os');
+const core = require('@actions/core');
 
-module.exports = (process.env['OS'] != 'Windows_NT') ? {
+const defaults = (process.env['OS'] != 'Windows_NT') ? {
     // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
     // Action runs, where $HOME is different from the pwent
     homePath: os.userInfo().homedir,
@@ -13,4 +14,15 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     sshAgentCmdDefault: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmdDefault: 'c://progra~1//git//usr//bin//ssh-add.exe',
     gitCmdDefault: 'c://progra~1//git//bin//git.exe'
+};
+
+const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
+const sshAddCmdInput = core.getInput('ssh-add-cmd');
+const gitCmdInput = core.getInput('git-cmd');
+
+module.exports = {
+    homePath: defaults.homePath,
+    sshAgentCmd: sshAgentCmdInput !== '' ? sshAgentCmdInput : defaults.sshAgentCmdDefault,
+    sshAddCmd: sshAddCmdInput !== '' ? sshAddCmdInput : defaults.sshAddCmdDefault,
+    gitCmd: gitCmdInput !== '' ? gitCmdInput : defaults.gitCmdDefault,
 };


### PR DESCRIPTION
## Summary

Fetch the latest from upstream including nodejs 24 support.

## Release Strategy

Keeping the `v0` tag at its current position so that consumers need to explicitly opt into this update by pinning to `v0.10.0`.